### PR TITLE
Fix compilation on OpenBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ objc = "0.2"
 objc_id = "0.1"
 objc-foundation = "0.1"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "openbsd"))'.dependencies]
 x11-clipboard = "0.3.0-alpha.1"

--- a/src/clipboard_metadata.rs
+++ b/src/clipboard_metadata.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 pub enum ClipboardContentType {
-	#[cfg(target_os="linux")]
+	#[cfg(any(target_os="linux", target_os="openbsd"))]
 	X11ContentType(X11ContentType),
 	#[cfg(target_os="windows")]
 	WinContentType(WinContentType),
@@ -10,7 +10,7 @@ pub enum ClipboardContentType {
 }
 
 /// See: https://tronche.com/gui/x/icccm/sec-2.html#s-2
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="openbsd"))]
 pub enum X11ContentType {
 	AdobePortableDocumentFormat,
 	ApplePict,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display, Formatter};
 
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="openbsd"))]
 use x11_clipboard::error::Error as X11Error;
 
 use std::string::FromUtf8Error;
@@ -12,7 +12,7 @@ pub enum ClipboardError {
     Unimplemented,
     IoError(IoError),
     EncodingError(FromUtf8Error),
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os="openbsd"))]
     X11ClipboardError(X11Error),
     #[cfg(target_os = "macos")]
     MacOsClipboardError(MacOsError),
@@ -62,7 +62,7 @@ impl From<WinError> for ClipboardError {
     }
 }
 
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="openbsd"))]
 impl From<X11Error> for ClipboardError {
     fn from(e: X11Error) -> Self {
         ClipboardError::X11ClipboardError(e)
@@ -108,7 +108,7 @@ impl Display for ClipboardError {
             Unimplemented => write!(f, "Clipboard::Unimplemented: Attempted to get or set the clipboard, which hasn't been implemented yet."),
             IoError(ref e) => write!(f, "Clipboard::IoError: {} cause: {:?}", e.description(), e.cause()),
             EncodingError(ref e) => write!(f, "Clipboard::EncodingError: {} cause: {:?}", e.description(), e.cause()),
-            #[cfg(target_os="linux")]
+            #[cfg(any(target_os="linux", target_os="openbsd"))]
             X11ClipboardError(ref e) => write!(f, "X11ClipboardError: {}", e),
             #[cfg(target_os="macos")]
             MacOsClipboardError(ref e) => write!(f, "MacOsClipboardError: {}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 #[cfg(target_os="windows")]
 extern crate clipboard_win;
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="openbsd"))]
 extern crate x11_clipboard;
 #[cfg(target_os="macos")]
 #[macro_use]
@@ -34,9 +34,9 @@ pub mod win;
 #[cfg(target_os="windows")]
 pub use win::WindowsClipboard as SystemClipboard;
 
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="openbsd"))]
 pub mod x11;
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="openbsd"))]
 pub use x11::X11Clipboard as SystemClipboard;
 
 #[cfg(target_os="macos")]


### PR DESCRIPTION
Hi,

this patch fixes compilation on OpenBSD by just treating it the same as Linux, i.e. just use the X11 clipboard.