### PR TITLE
Implement `Error` for `ClipboardError`

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,7 +3,9 @@ extern crate clipboard2;
 use clipboard2::{Clipboard, SystemClipboard};
 
 fn main() {
-	let clipboard = SystemClipboard::new().unwrap();
-	clipboard.set_string_contents(String::from("Hello")).unwrap();
-	println!("{}", clipboard.get_string_contents().unwrap());
+    let clipboard = SystemClipboard::new().unwrap();
+    clipboard
+        .set_string_contents(String::from("Hello"))
+        .unwrap();
+    println!("{}", clipboard.get_string_contents().unwrap());
 }

--- a/src/clipboard_metadata.rs
+++ b/src/clipboard_metadata.rs
@@ -1,223 +1,223 @@
 #![allow(dead_code)]
 
 pub enum ClipboardContentType {
-	#[cfg(any(target_os="linux", target_os="openbsd"))]
-	X11ContentType(X11ContentType),
-	#[cfg(target_os="windows")]
-	WinContentType(WinContentType),
-	#[cfg(target_os="macos")]
-	MacContent,
+    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
+    X11ContentType(X11ContentType),
+    #[cfg(target_os = "windows")]
+    WinContentType(WinContentType),
+    #[cfg(target_os = "macos")]
+    MacContent,
 }
 
 /// See: https://tronche.com/gui/x/icccm/sec-2.html#s-2
-#[cfg(any(target_os="linux", target_os="openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 pub enum X11ContentType {
-	AdobePortableDocumentFormat,
-	ApplePict,
-	/// A list of pixel values
-	Background,
-	/// A list of bitmap IDs
-	Bitmap,
-	/// The start and end of the selection in bytes
-	CharacterPosition,
-	Class,
-	/// Any top-level window owned by the selection owner
-	ClientWindow,
-	/// A list of colormap IDs
-	Colormap,
-	/// The start and end column numbers
-	ColumnNumber,
-	/// Compound Text
-	CompoundText,
-	Delete,
-	/// A list of drawable IDs
-	Drawable,
-	Eps,
-	EpsInterchange,
-	/// The full path name of a file
-	FileName,
-	/// A list of pixel values
-	Foreground,
-	HostName,
-	InsertProperty,
-	InsertSelection,
-	/// The number of bytes in the selection
-	Length,
-	/// The start and end line numbers
-	LineNumber,
-	/// The number of disjoint parts of the selection
-	ListLength,
-	/// The name of the selected procedure
-	Module,
-	Multiple,
-	Name,
-	/// ISO Office Document Interchange Format
-	Odif,
-	/// The operating system of the owner client
-	OwnerOs,
-	/// A list of pixmap IDs
-	Pixmap,
-	Postscript,
-	/// The name of the selected procedure
-	Procedure,
-	/// The process ID of the owner
-	Process,
-	/// ISO Latin-1 (+TAB+NEWLINE) text
-	String,
-	/// A list of valid target atoms
-	Targets,
-	/// The task ID of the owner
-	Task,
-	/// The text in the owner's choice of encoding
-	Text,
-	/// The timestamp used to acquire the selection
-	Timestamp,
-	/// The name of the user running the owner
-	User,
+    AdobePortableDocumentFormat,
+    ApplePict,
+    /// A list of pixel values
+    Background,
+    /// A list of bitmap IDs
+    Bitmap,
+    /// The start and end of the selection in bytes
+    CharacterPosition,
+    Class,
+    /// Any top-level window owned by the selection owner
+    ClientWindow,
+    /// A list of colormap IDs
+    Colormap,
+    /// The start and end column numbers
+    ColumnNumber,
+    /// Compound Text
+    CompoundText,
+    Delete,
+    /// A list of drawable IDs
+    Drawable,
+    Eps,
+    EpsInterchange,
+    /// The full path name of a file
+    FileName,
+    /// A list of pixel values
+    Foreground,
+    HostName,
+    InsertProperty,
+    InsertSelection,
+    /// The number of bytes in the selection
+    Length,
+    /// The start and end line numbers
+    LineNumber,
+    /// The number of disjoint parts of the selection
+    ListLength,
+    /// The name of the selected procedure
+    Module,
+    Multiple,
+    Name,
+    /// ISO Office Document Interchange Format
+    Odif,
+    /// The operating system of the owner client
+    OwnerOs,
+    /// A list of pixmap IDs
+    Pixmap,
+    Postscript,
+    /// The name of the selected procedure
+    Procedure,
+    /// The process ID of the owner
+    Process,
+    /// ISO Latin-1 (+TAB+NEWLINE) text
+    String,
+    /// A list of valid target atoms
+    Targets,
+    /// The task ID of the owner
+    Task,
+    /// The text in the owner's choice of encoding
+    Text,
+    /// The timestamp used to acquire the selection
+    Timestamp,
+    /// The name of the user running the owner
+    User,
 }
 
 /// See https://msdn.microsoft.com/en-us/library/windows/desktop/ff729168%28v=vs.85%29.aspx
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WinContentType {
-	///  A handle to a bitmap (HBITMAP)
-	Bitmap,
-	/// A memory object containing a BITMAPINFO structure followed by the bitmap bits.
-	Dib,
-	/// A memory object containing a BITMAPV5HEADER structure followed by
-	/// the bitmap color space information and the bitmap bits.
-	Dib5,
-	/// Software Arts' Data Interchange Format.
-	Dif,
-	/// Bitmap display format associated with a private format. The hMem parameter must be a
-	/// handle to data that can be displayed in bitmap format in lieu of the privately
-	/// formatted data.
-	DspBitmap,
-	/// CF_DSPENHMETAFILE: Enhanced metafile display format associated with a private
-	/// format. The hMem parameter must be a handle to data that can be displayed in
-	/// enhanced metafile format in lieu of the privately formatted data.
-	DspEnhancedMetaFile,
-	/// CF_DSPMETAFILEPICT: Metafile-picture display format associated with a private
-	/// format. The hMem parameter must be a handle to data that can be displayed in
-	/// metafile-picture format in lieu of the privately formatted data.
-	DspMetaFilePict,
-	/// Text display format associated with a private format. The hMem parameter must
-	/// be a handle to data that can be displayed in text format in lieu of the
-	/// privately formatted data.
-	DspText,
-	/// A handle to an enhanced metafile (HENHMETAFILE).
-	EnhancedMetaFile,
-	/// Start of a range of integer values for application-defined
-	/// GDI object clipboard formats.
-	GdiObjectFirst,
-	/// End of a range of integer values for application-defined GDI
-	/// object clipboard formats.
-	GdiObjectLast,
-	/// A handle to type HDROP that identifies a list of files.
-	HDrop,
-	/// The data is a handle to the locale identifier associated
-	/// with text in the clipboard.
-	Locale,
-	/// Handle to a metafile picture format as defined by the METAFILEPICT structure.
-	MetaFilePict,
-	/// Text format containing characters in the OEM character set.
-	OemText,
-	/// Owner-display format
-	OwnerDisplay,
-	/// Handle to a color palette
-	Palette,
-	/// Data for the pen extensions to the Microsoft Windows for Pen Computing
-	PenData,
-	/// Start of a range of integer values for private clipboard formats
-	PrivateFirst,
-	/// End of a range of integer values for private clipboard formats
-	PrivateLast,
-	/// Represents audio data more complex than can be represented in a CF_WAVE standard wave format
-	Riff,
-	/// Microsoft Symbolic Link (SYLK) format
-	Sylk,
-	/// ANSI text format
-	Text,
-	/// Tagged-image file format
-	Tiff,
-	/// UTF16 text format
-	UnicodeText,
-	/// Represents audio data in one of the standard wave formats
-	Wave,
-	/// Custom content type, used as backup if none of the formats are known
-	Custom(u32),
+    ///  A handle to a bitmap (HBITMAP)
+    Bitmap,
+    /// A memory object containing a BITMAPINFO structure followed by the bitmap bits.
+    Dib,
+    /// A memory object containing a BITMAPV5HEADER structure followed by
+    /// the bitmap color space information and the bitmap bits.
+    Dib5,
+    /// Software Arts' Data Interchange Format.
+    Dif,
+    /// Bitmap display format associated with a private format. The hMem parameter must be a
+    /// handle to data that can be displayed in bitmap format in lieu of the privately
+    /// formatted data.
+    DspBitmap,
+    /// CF_DSPENHMETAFILE: Enhanced metafile display format associated with a private
+    /// format. The hMem parameter must be a handle to data that can be displayed in
+    /// enhanced metafile format in lieu of the privately formatted data.
+    DspEnhancedMetaFile,
+    /// CF_DSPMETAFILEPICT: Metafile-picture display format associated with a private
+    /// format. The hMem parameter must be a handle to data that can be displayed in
+    /// metafile-picture format in lieu of the privately formatted data.
+    DspMetaFilePict,
+    /// Text display format associated with a private format. The hMem parameter must
+    /// be a handle to data that can be displayed in text format in lieu of the
+    /// privately formatted data.
+    DspText,
+    /// A handle to an enhanced metafile (HENHMETAFILE).
+    EnhancedMetaFile,
+    /// Start of a range of integer values for application-defined
+    /// GDI object clipboard formats.
+    GdiObjectFirst,
+    /// End of a range of integer values for application-defined GDI
+    /// object clipboard formats.
+    GdiObjectLast,
+    /// A handle to type HDROP that identifies a list of files.
+    HDrop,
+    /// The data is a handle to the locale identifier associated
+    /// with text in the clipboard.
+    Locale,
+    /// Handle to a metafile picture format as defined by the METAFILEPICT structure.
+    MetaFilePict,
+    /// Text format containing characters in the OEM character set.
+    OemText,
+    /// Owner-display format
+    OwnerDisplay,
+    /// Handle to a color palette
+    Palette,
+    /// Data for the pen extensions to the Microsoft Windows for Pen Computing
+    PenData,
+    /// Start of a range of integer values for private clipboard formats
+    PrivateFirst,
+    /// End of a range of integer values for private clipboard formats
+    PrivateLast,
+    /// Represents audio data more complex than can be represented in a CF_WAVE standard wave format
+    Riff,
+    /// Microsoft Symbolic Link (SYLK) format
+    Sylk,
+    /// ANSI text format
+    Text,
+    /// Tagged-image file format
+    Tiff,
+    /// UTF16 text format
+    UnicodeText,
+    /// Represents audio data in one of the standard wave formats
+    Wave,
+    /// Custom content type, used as backup if none of the formats are known
+    Custom(u32),
 }
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 impl WinContentType {
-	/// Toggles through the clipboard types
-	pub(crate) fn next(&self) -> Option<Self> {
-		use self::WinContentType::*;
-		match self {
-			Bitmap => Some(Dib),
-			Dib => Some(Dib5),
-			Dib5 => Some(Dif),
-			Dif => Some(DspBitmap),
-			DspBitmap => Some(DspEnhancedMetaFile),
-			DspEnhancedMetaFile => Some(DspMetaFilePict),
-			DspMetaFilePict => Some(DspText),
-			DspText => Some(EnhancedMetaFile),
-			EnhancedMetaFile => Some(GdiObjectFirst),
-			GdiObjectFirst => Some(GdiObjectLast),
-			GdiObjectLast => Some(HDrop),
-			HDrop => Some(Locale),
-			Locale => Some(MetaFilePict),
-			MetaFilePict => Some(OemText),
-			OemText => Some(OwnerDisplay),
-			OwnerDisplay => Some(Palette),
-			Palette => Some(PenData),
-			PenData => Some(PrivateFirst),
-			PrivateFirst => Some(PrivateLast),
-			PrivateLast => Some(Riff),
-			Riff => Some(Sylk),
-			Sylk => Some(Text),
-			Text => Some(Tiff),
-			Tiff => Some(UnicodeText),
-			UnicodeText => Some(Wave),
-			Wave => Some(Custom((*self).into())),
-			Custom(_) => None,
-		}
-	}
+    /// Toggles through the clipboard types
+    pub(crate) fn next(&self) -> Option<Self> {
+        use self::WinContentType::*;
+        match self {
+            Bitmap => Some(Dib),
+            Dib => Some(Dib5),
+            Dib5 => Some(Dif),
+            Dif => Some(DspBitmap),
+            DspBitmap => Some(DspEnhancedMetaFile),
+            DspEnhancedMetaFile => Some(DspMetaFilePict),
+            DspMetaFilePict => Some(DspText),
+            DspText => Some(EnhancedMetaFile),
+            EnhancedMetaFile => Some(GdiObjectFirst),
+            GdiObjectFirst => Some(GdiObjectLast),
+            GdiObjectLast => Some(HDrop),
+            HDrop => Some(Locale),
+            Locale => Some(MetaFilePict),
+            MetaFilePict => Some(OemText),
+            OemText => Some(OwnerDisplay),
+            OwnerDisplay => Some(Palette),
+            Palette => Some(PenData),
+            PenData => Some(PrivateFirst),
+            PrivateFirst => Some(PrivateLast),
+            PrivateLast => Some(Riff),
+            Riff => Some(Sylk),
+            Sylk => Some(Text),
+            Text => Some(Tiff),
+            Tiff => Some(UnicodeText),
+            UnicodeText => Some(Wave),
+            Wave => Some(Custom((*self).into())),
+            Custom(_) => None,
+        }
+    }
 }
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 impl Into<u32> for WinContentType {
-	fn into(self) -> u32 {
-		use self::WinContentType::*;
-		use clipboard_win::formats::*;
-		match self {
-			Bitmap => CF_BITMAP,
-			Custom(a) => a,
-			Dib => CF_DIB,
-			Dib5 => CF_DIBV5,
-			Dif => CF_DIF,
-			DspBitmap => CF_DSPBITMAP,
-			DspEnhancedMetaFile => CF_DSPENHMETAFILE,
-			DspMetaFilePict => CF_DSPMETAFILEPICT,
-			DspText => CF_DSPTEXT,
-			EnhancedMetaFile => CF_ENHMETAFILE,
-			GdiObjectFirst => CF_GDIOBJFIRST,
-			GdiObjectLast =>CF_GDIOBJLAST,
-			HDrop => CF_HDROP,
-			Locale => CF_LOCALE,
-			MetaFilePict => CF_METAFILEPICT,
-			OemText => CF_OEMTEXT,
-			OwnerDisplay => CF_OWNERDISPLAY,
-			Palette => CF_PALETTE,
-			PenData => CF_PENDATA,
-			PrivateFirst => CF_PRIVATEFIRST,
-			PrivateLast => CF_PRIVATELAST,
-			Riff => CF_RIFF,
-			Sylk => CF_SYLK,
-			Text => CF_TEXT,
-			Tiff => CF_TIFF,
-			UnicodeText => CF_UNICODETEXT,
-			Wave => CF_WAVE,
-		}
-	}
+    fn into(self) -> u32 {
+        use self::WinContentType::*;
+        use clipboard_win::formats::*;
+        match self {
+            Bitmap => CF_BITMAP,
+            Custom(a) => a,
+            Dib => CF_DIB,
+            Dib5 => CF_DIBV5,
+            Dif => CF_DIF,
+            DspBitmap => CF_DSPBITMAP,
+            DspEnhancedMetaFile => CF_DSPENHMETAFILE,
+            DspMetaFilePict => CF_DSPMETAFILEPICT,
+            DspText => CF_DSPTEXT,
+            EnhancedMetaFile => CF_ENHMETAFILE,
+            GdiObjectFirst => CF_GDIOBJFIRST,
+            GdiObjectLast => CF_GDIOBJLAST,
+            HDrop => CF_HDROP,
+            Locale => CF_LOCALE,
+            MetaFilePict => CF_METAFILEPICT,
+            OemText => CF_OEMTEXT,
+            OwnerDisplay => CF_OWNERDISPLAY,
+            Palette => CF_PALETTE,
+            PenData => CF_PENDATA,
+            PrivateFirst => CF_PRIVATEFIRST,
+            PrivateLast => CF_PRIVATELAST,
+            Riff => CF_RIFF,
+            Sylk => CF_SYLK,
+            Text => CF_TEXT,
+            Tiff => CF_TIFF,
+            UnicodeText => CF_UNICODETEXT,
+            Wave => CF_WAVE,
+        }
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,18 +1,18 @@
 use std::fmt::{self, Display, Formatter};
 
-#[cfg(any(target_os="linux", target_os="openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 use x11_clipboard::error::Error as X11Error;
 
-use std::string::FromUtf8Error;
 use std::error::Error;
 use std::io::Error as IoError;
+use std::string::FromUtf8Error;
 
 #[derive(Debug)]
 pub enum ClipboardError {
     Unimplemented,
     IoError(IoError),
     EncodingError(FromUtf8Error),
-    #[cfg(any(target_os = "linux", target_os="openbsd"))]
+    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
     X11ClipboardError(X11Error),
     #[cfg(target_os = "macos")]
     MacOsClipboardError(MacOsError),
@@ -20,7 +20,7 @@ pub enum ClipboardError {
     WindowsClipboardError(WinError),
 }
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum WinError {
     EmptyClipboard,
@@ -40,7 +40,7 @@ impl Error for WinError {
         use self::WinError::*;
         match *self {
             EmptyClipboard => "Empty clipboard or couldn't determine format of clipboard contents",
-            FormatNoSize => "Could not determine the length of the clipboard contents"
+            FormatNoSize => "Could not determine the length of the clipboard contents",
         }
     }
 
@@ -55,21 +55,21 @@ impl From<IoError> for ClipboardError {
     }
 }
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 impl From<WinError> for ClipboardError {
     fn from(e: WinError) -> Self {
         ClipboardError::WindowsClipboardError(e)
     }
 }
 
-#[cfg(any(target_os="linux", target_os="openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 impl From<X11Error> for ClipboardError {
     fn from(e: X11Error) -> Self {
         ClipboardError::X11ClipboardError(e)
     }
 }
 
-#[cfg(target_os="macos")]
+#[cfg(target_os = "macos")]
 impl From<MacOsError> for ClipboardError {
     fn from(e: MacOsError) -> Self {
         ClipboardError::MacOsClipboardError(e)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,21 +30,21 @@ pub enum WinError {
 #[cfg(target_os = "windows")]
 impl Display for WinError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(
+            f,
+            "{}",
+            match *self {
+                EmptyClipboard =>
+                    "Empty clipboard or couldn't determine format of clipboard contents",
+                FormatNoSize => "Could not determine the length of the clipboard contents",
+            }
+        )
     }
 }
 
 #[cfg(target_os = "windows")]
 impl Error for WinError {
-    fn description(&self) -> &str {
-        use self::WinError::*;
-        match *self {
-            EmptyClipboard => "Empty clipboard or couldn't determine format of clipboard contents",
-            FormatNoSize => "Could not determine the length of the clipboard contents",
-        }
-    }
-
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }
 }
@@ -106,14 +106,14 @@ impl Display for ClipboardError {
         use self::ClipboardError::*;
         match self {
             Unimplemented => write!(f, "Clipboard::Unimplemented: Attempted to get or set the clipboard, which hasn't been implemented yet."),
-            IoError(ref e) => write!(f, "Clipboard::IoError: {} cause: {:?}", e.description(), e.cause()),
-            EncodingError(ref e) => write!(f, "Clipboard::EncodingError: {} cause: {:?}", e.description(), e.cause()),
+            IoError(ref e) => write!(f, "Clipboard::IoError: {} cause: {:?}", e, e.source()),
+            EncodingError(ref e) => write!(f, "Clipboard::EncodingError: {} cause: {:?}", e, e.source()),
             #[cfg(any(target_os="linux", target_os="openbsd"))]
             X11ClipboardError(ref e) => write!(f, "X11ClipboardError: {}", e),
             #[cfg(target_os="macos")]
             MacOsClipboardError(ref e) => write!(f, "MacOsClipboardError: {}", e),
             #[cfg(target_os="windows")]
-            WindowsClipboardError(ref e) => write!(f, "WindowsClipboardError: {} cause: {:?}", e.description(), e.cause()),
+            WindowsClipboardError(ref e) => write!(f, "WindowsClipboardError: {} cause: {:?}", e, e.source()),
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -123,3 +123,23 @@ impl From<FromUtf8Error> for ClipboardError {
         ClipboardError::EncodingError(e)
     }
 }
+
+impl Error for ClipboardError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use self::ClipboardError::*;
+        match self {
+            Unimplemented => None,
+            IoError(ref error) => Some(error),
+            EncodingError(ref error) => Some(error),
+
+            #[cfg(any(target_os = "linux", target_os = "openbsd"))]
+            X11ClipboardError(ref error) => Some(error),
+
+            #[cfg(target_os = "macos")]
+            MacOsClipboardError(ref error) => Some(error),
+
+            #[cfg(target_os = "windows")]
+            WindowsClipboardError(ref error) => Some(error),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,44 +2,48 @@
 //!
 //! Fork of https://github.com/aweinstock314/rust-clipboard with better error handling
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 extern crate clipboard_win;
-#[cfg(any(target_os="linux", target_os="openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 extern crate x11_clipboard;
-#[cfg(target_os="macos")]
+#[cfg(target_os = "macos")]
 #[macro_use]
 extern crate objc;
-#[cfg(target_os="macos")]
-extern crate objc_id;
-#[cfg(target_os="macos")]
+#[cfg(target_os = "macos")]
 extern crate objc_foundation;
+#[cfg(target_os = "macos")]
+extern crate objc_id;
 
-mod errors;
 pub mod clipboard_metadata;
+mod errors;
 
-pub use errors::ClipboardError;
 pub use clipboard_metadata::ClipboardContentType;
+pub use errors::ClipboardError;
 
 pub trait Clipboard {
-	type Output;
-	fn new() -> Result<Self::Output, ClipboardError>;
-	fn get_contents(&self) -> Result<(Vec<u8>, ClipboardContentType), ClipboardError>;
-	fn get_string_contents(&self) -> Result<String, ClipboardError>;
-	fn set_contents(&self, contents: Vec<u8>, format: ClipboardContentType) -> Result<(), ClipboardError>;
-	fn set_string_contents(&self, contents: String) -> Result<(), ClipboardError>;
+    type Output;
+    fn new() -> Result<Self::Output, ClipboardError>;
+    fn get_contents(&self) -> Result<(Vec<u8>, ClipboardContentType), ClipboardError>;
+    fn get_string_contents(&self) -> Result<String, ClipboardError>;
+    fn set_contents(
+        &self,
+        contents: Vec<u8>,
+        format: ClipboardContentType,
+    ) -> Result<(), ClipboardError>;
+    fn set_string_contents(&self, contents: String) -> Result<(), ClipboardError>;
 }
 
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 pub mod win;
-#[cfg(target_os="windows")]
+#[cfg(target_os = "windows")]
 pub use win::WindowsClipboard as SystemClipboard;
 
-#[cfg(any(target_os="linux", target_os="openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 pub mod x11;
-#[cfg(any(target_os="linux", target_os="openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "openbsd"))]
 pub use x11::X11Clipboard as SystemClipboard;
 
-#[cfg(target_os="macos")]
+#[cfg(target_os = "macos")]
 pub mod macos;
-#[cfg(target_os="macos")]
+#[cfg(target_os = "macos")]
 pub use macos::MacOsClipboard as SystemClipboard;

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,94 +1,85 @@
-use {
-	Clipboard,
-	errors::{ClipboardError, MacOsError},
-	clipboard_metadata::ClipboardContentType,
-};
-use objc::runtime::{Object, Class};
-use objc_foundation::{
-	INSArray, INSString, INSObject,
-	NSArray, NSDictionary, NSString, NSObject
-};
+use objc::runtime::{Class, Object};
+use objc_foundation::{INSArray, INSObject, INSString, NSArray, NSDictionary, NSObject, NSString};
 use objc_id::{Id, Owned};
 use std::mem::transmute;
+use {
+    clipboard_metadata::ClipboardContentType,
+    errors::{ClipboardError, MacOsError},
+    Clipboard,
+};
 
 // required to bring NSPasteboard into the path of the class-resolver
 #[link(name = "AppKit", kind = "framework")]
-extern "C" { }
+extern "C" {}
 
 pub struct MacOsClipboard {
-	pasteboard: Id<Object>,
+    pasteboard: Id<Object>,
 }
 
 impl Clipboard for MacOsClipboard {
+    type Output = Self;
 
-	type Output = Self;
+    fn new() -> Result<Self::Output, ClipboardError> {
+        let cls = Class::get("NSPasteboard").ok_or(MacOsError::PasteboardNotFound)?;
+        let pasteboard: *mut Object = unsafe { msg_send![cls, generalPasteboard] };
+        if pasteboard.is_null() {
+            return Err(MacOsError::NullPasteboard.into());
+        }
+        let pasteboard: Id<Object> = unsafe { Id::from_ptr(pasteboard) };
+        Ok(MacOsClipboard {
+            pasteboard: pasteboard,
+        })
+    }
 
-	fn new()
-	-> Result<Self::Output, ClipboardError>
-	{
-		let cls = Class::get("NSPasteboard").ok_or(MacOsError::PasteboardNotFound)?;
-		let pasteboard: *mut Object = unsafe { msg_send![cls, generalPasteboard] };
-		if pasteboard.is_null() {
-		    return Err(MacOsError::NullPasteboard.into());
-		}
-		let pasteboard: Id<Object> = unsafe { Id::from_ptr(pasteboard) };
-		Ok(MacOsClipboard { pasteboard: pasteboard })
-	}
+    /// # **WARNING**: Unimplemented, use `get_string_contents`
+    fn get_contents(&self) -> Result<(Vec<u8>, ClipboardContentType), ClipboardError> {
+        Err(ClipboardError::Unimplemented)
+    }
 
-	/// # **WARNING**: Unimplemented, use `get_string_contents`
-	fn get_contents(&self)
-	-> Result<(Vec<u8>, ClipboardContentType), ClipboardError>
-	{
-		Err(ClipboardError::Unimplemented)
-	}
+    fn get_string_contents(&self) -> Result<String, ClipboardError> {
+        let string_class: Id<NSObject> = {
+            let cls: Id<Class> = unsafe { Id::from_ptr(class("NSString")) };
+            unsafe { transmute(cls) }
+        };
 
-	fn get_string_contents(&self)
-	-> Result<String, ClipboardError>
-	{
-		let string_class: Id<NSObject> = {
-		    let cls: Id<Class> = unsafe { Id::from_ptr(class("NSString")) };
-		    unsafe { transmute(cls) }
-		};
+        let classes: Id<NSArray<NSObject, Owned>> = NSArray::from_vec(vec![string_class]);
+        let options: Id<NSDictionary<NSObject, NSObject>> = NSDictionary::new();
 
-		let classes: Id<NSArray<NSObject, Owned>> = NSArray::from_vec(vec![string_class]);
-		let options: Id<NSDictionary<NSObject, NSObject>> = NSDictionary::new();
+        let string_array: Id<NSArray<NSString>> = unsafe {
+            let obj: *mut NSArray<NSString> =
+                msg_send![self.pasteboard, readObjectsForClasses:&*classes options:&*options];
+            if obj.is_null() {
+                return Err(MacOsError::ReadObjectsForClassesNull.into());
+            }
+            Id::from_ptr(obj)
+        };
 
-		let string_array: Id<NSArray<NSString>> = unsafe {
-		    let obj: *mut NSArray<NSString> =
-		        msg_send![self.pasteboard, readObjectsForClasses:&*classes options:&*options];
-		    if obj.is_null() {
-		        return Err(MacOsError::ReadObjectsForClassesNull.into());
-		    }
-		    Id::from_ptr(obj)
-		};
+        if string_array.count() == 0 {
+            Err(MacOsError::ReadObjectsForClassesEmpty.into())
+        } else {
+            Ok(string_array[0].as_str().to_owned())
+        }
+    }
 
-		if string_array.count() == 0 {
-		    Err(MacOsError::ReadObjectsForClassesEmpty.into())
-		} else {
-		    Ok(string_array[0].as_str().to_owned())
-		}
-	}
+    /// # **WARNING**: Unimplemented, use `get_string_contents`
+    fn set_contents(
+        &self,
+        contents: Vec<u8>,
+        _: ClipboardContentType,
+    ) -> Result<(), ClipboardError> {
+        Err(ClipboardError::Unimplemented)
+    }
 
-	/// # **WARNING**: Unimplemented, use `get_string_contents`
-	fn set_contents(&self, contents: Vec<u8>, _: ClipboardContentType)
-	-> Result<(), ClipboardError>
-	{
-		Err(ClipboardError::Unimplemented)
-	}
-
-	fn set_string_contents(&self, contents: String)
-	-> Result<(), ClipboardError>
-	{
-		let string_array = NSArray::from_vec(vec![NSString::from_str(&contents)]);
-		let _: usize = unsafe { msg_send![self.pasteboard, clearContents] };
-		let success: bool = unsafe { msg_send![self.pasteboard, writeObjects:string_array] };
-		return if success {
-		    Ok(())
-		} else {
-		    Err(MacOsError::PasteWriteObjectsError.into())
-		};
-	}
-
+    fn set_string_contents(&self, contents: String) -> Result<(), ClipboardError> {
+        let string_array = NSArray::from_vec(vec![NSString::from_str(&contents)]);
+        let _: usize = unsafe { msg_send![self.pasteboard, clearContents] };
+        let success: bool = unsafe { msg_send![self.pasteboard, writeObjects: string_array] };
+        return if success {
+            Ok(())
+        } else {
+            Err(MacOsError::PasteWriteObjectsError.into())
+        };
+    }
 }
 
 // This is a convenience function that both cocoa-rs and

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,64 +1,61 @@
 use {
-	Clipboard,
-	errors::{ClipboardError, WinError},
-	clipboard_metadata::{WinContentType, ClipboardContentType}
+    clipboard_metadata::{ClipboardContentType, WinContentType},
+    errors::{ClipboardError, WinError},
+    Clipboard,
 };
 
-use clipboard_win::{
-	Clipboard as SystemClipboard,
-	raw::is_format_avail,
-};
+use clipboard_win::{raw::is_format_avail, Clipboard as SystemClipboard};
 
-pub struct WindowsClipboard { }
+pub struct WindowsClipboard {}
 
 impl Clipboard for WindowsClipboard {
-	type Output = Self;
+    type Output = Self;
 
-	fn new() -> Result<Self::Output, ClipboardError> {
-		Ok(WindowsClipboard { })
-	}
+    fn new() -> Result<Self::Output, ClipboardError> {
+        Ok(WindowsClipboard {})
+    }
 
-	fn get_contents(&self)
-	-> Result<(Vec<u8>, ClipboardContentType), ClipboardError>
-	{
-		let clipboard = SystemClipboard::new()?;
-		let mut format = WinContentType::Bitmap;
-		loop {
-			if is_format_avail(format.into()) {
-				let format_size = match clipboard.size(format.into()) {
-					Some(s) => s,
-					None => return Err(WinError::FormatNoSize.into()),
-				};
-				let mut vec = vec![0; format_size];
-				clipboard.get(format.into(), &mut vec)?;
-				return Ok((vec, ClipboardContentType::WinContentType(format)));
-			} else {
-				match format.next() {
-					Some(f) => format = f,
-					None => return Err(WinError::EmptyClipboard.into()),
-				}
-			}
-		}
-	}
+    fn get_contents(&self) -> Result<(Vec<u8>, ClipboardContentType), ClipboardError> {
+        let clipboard = SystemClipboard::new()?;
+        let mut format = WinContentType::Bitmap;
+        loop {
+            if is_format_avail(format.into()) {
+                let format_size = match clipboard.size(format.into()) {
+                    Some(s) => s,
+                    None => return Err(WinError::FormatNoSize.into()),
+                };
+                let mut vec = vec![0; format_size];
+                clipboard.get(format.into(), &mut vec)?;
+                return Ok((vec, ClipboardContentType::WinContentType(format)));
+            } else {
+                match format.next() {
+                    Some(f) => format = f,
+                    None => return Err(WinError::EmptyClipboard.into()),
+                }
+            }
+        }
+    }
 
-	fn get_string_contents(&self)
-	-> Result<String, ClipboardError>
-	{
-		SystemClipboard::new()?.get_string().map_err(|e| e.into())
-	}
+    fn get_string_contents(&self) -> Result<String, ClipboardError> {
+        SystemClipboard::new()?.get_string().map_err(|e| e.into())
+    }
 
-	fn set_contents(&self, contents: Vec<u8>, format: ClipboardContentType)
-	-> Result<(), ClipboardError>
-	{
-		let win_content_type = match format {
-			ClipboardContentType::WinContentType(w) => w,
-		};
-		SystemClipboard::new()?.set(win_content_type.into(), &contents).map_err(|e| e.into())
-	}
+    fn set_contents(
+        &self,
+        contents: Vec<u8>,
+        format: ClipboardContentType,
+    ) -> Result<(), ClipboardError> {
+        let win_content_type = match format {
+            ClipboardContentType::WinContentType(w) => w,
+        };
+        SystemClipboard::new()?
+            .set(win_content_type.into(), &contents)
+            .map_err(|e| e.into())
+    }
 
-	fn set_string_contents(&self, contents: String)
-	-> Result<(), ClipboardError>
-	{
-		SystemClipboard::new()?.set_string(&contents).map_err(|e| e.into())
-	}
+    fn set_string_contents(&self, contents: String) -> Result<(), ClipboardError> {
+        SystemClipboard::new()?
+            .set_string(&contents)
+            .map_err(|e| e.into())
+    }
 }

--- a/src/x11.rs
+++ b/src/x11.rs
@@ -1,58 +1,48 @@
-use {
-	Clipboard,
-	errors::ClipboardError,
-	clipboard_metadata::ClipboardContentType,
-};
-use x11_clipboard::Clipboard as SystemClipboard;
 use std::time::Duration;
+use x11_clipboard::Clipboard as SystemClipboard;
+use {clipboard_metadata::ClipboardContentType, errors::ClipboardError, Clipboard};
 
 pub struct X11Clipboard {
-	inner: SystemClipboard,
+    inner: SystemClipboard,
 }
 
 impl Clipboard for X11Clipboard {
+    type Output = Self;
 
-	type Output = Self;
+    fn new() -> Result<Self::Output, ClipboardError> {
+        Ok(X11Clipboard {
+            inner: SystemClipboard::new()?,
+        })
+    }
 
-	fn new() 
-	-> Result<Self::Output, ClipboardError> 
-	{
-		Ok(X11Clipboard {
-			inner: SystemClipboard::new()?
-		})
-	}
+    /// # **WARNING**: Unimplemented, use `get_string_contents`
+    fn get_contents(&self) -> Result<(Vec<u8>, ClipboardContentType), ClipboardError> {
+        Err(ClipboardError::Unimplemented)
+    }
 
-	/// # **WARNING**: Unimplemented, use `get_string_contents`
-	fn get_contents(&self)
-	-> Result<(Vec<u8>, ClipboardContentType), ClipboardError> 
-	{
-		Err(ClipboardError::Unimplemented)
-	}
+    fn get_string_contents(&self) -> Result<String, ClipboardError> {
+        Ok(String::from_utf8(self.inner.load(
+            self.inner.getter.atoms.primary,
+            self.inner.getter.atoms.utf8_string,
+            self.inner.getter.atoms.property,
+            Duration::from_secs(3),
+        )?)?)
+    }
 
-	fn get_string_contents(&self) -> Result<String, ClipboardError> 
-	{
-		Ok(String::from_utf8(self.inner.load(
-		    self.inner.getter.atoms.primary,
-		    self.inner.getter.atoms.utf8_string,
-		    self.inner.getter.atoms.property,
-		    Duration::from_secs(3),
-		)?)?)
-	}
+    /// # **WARNING**: Unimplemented, use `set_string_contents`
+    fn set_contents(
+        &self,
+        _contents: Vec<u8>,
+        _: ClipboardContentType,
+    ) -> Result<(), ClipboardError> {
+        Err(ClipboardError::Unimplemented)
+    }
 
-	/// # **WARNING**: Unimplemented, use `set_string_contents`
-	fn set_contents(&self, _contents: Vec<u8>, _: ClipboardContentType) 
-	-> Result<(), ClipboardError>
-	{
-		Err(ClipboardError::Unimplemented)
-	}
-
-	fn set_string_contents(&self, contents: String) 
-	-> Result<(), ClipboardError> 
-	{
-		Ok(self.inner.store(
-		    self.inner.getter.atoms.primary,
-		    self.inner.setter.atoms.utf8_string,
-		    &*contents,
-		)?)
-	}
+    fn set_string_contents(&self, contents: String) -> Result<(), ClipboardError> {
+        Ok(self.inner.store(
+            self.inner.getter.atoms.primary,
+            self.inner.setter.atoms.utf8_string,
+            &*contents,
+        )?)
+    }
 }


### PR DESCRIPTION
Implements `std::error::Error` for `ClipboardError` such that it can be used with `?` syntax.

As groundwork, it runs `cargo fmt` on the code base and removes uses of the now deprecated `cause` and `description` methods on `Error` types.